### PR TITLE
[style/#14] build.gradle.kts 내 signingConfig 오타 수정

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -29,7 +29,7 @@ android {
 
     signingConfigs {
         getByName("debug") {
-            keyAlias = "${properties["DEUBG_KEY_ALIAS"]}"
+            keyAlias = "${properties["DEBUG_KEY_ALIAS"]}"
             keyPassword = "${properties["DEBUG_KEY_PASSWORD"]}"
             storeFile = File("${project.rootDir.absolutePath}/keystore/debug.keystore")
             storePassword = "${properties["DEBUG_KEY_PASSWORD"]}"


### PR DESCRIPTION
## Related Issues
- #14 

## What Did You Do?
- [x] `DEUBG` -> `DEBUG` 수정

- 위 사항과 관련하여 각 안드로이드 개발자분들께서는 `local.properties`에서 `DEUBG_KEY_ALIAS`의 key name을 `DEBUG_KEY_ALIAS`로 최신화 요청드립니다.

- close #14 